### PR TITLE
Refactor desktop build for Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -22,9 +22,9 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
-      - name: Build app for Windows
-        run: npm run build
+      - name: Build app for Linux
+        run: npm run build:release:linux
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,18 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            build_command: npm run build:release:linux
+            label: Linux
+          - os: windows-latest
+            build_command: npm run build:release:windows
+            label: Windows
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -24,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build app for Linux
-        run: npm run build:release:linux
+      - name: Build app for ${{ matrix.label }}
+        run: ${{ matrix.build_command }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Stable Version: [ICC Plus 2](https://hikawasisters.neocities.org/ICCPlus2/)<br><
 Legacy Version: [ICC Plus](https://hikawasisters.neocities.org/ICCPlus/)<br>
 <i>This version is no longer maintained.</i><br>
 
+## Desktop Build
+- Local Linux build: `npm run build:linux`
+- Cross-platform local default: `npm run build`
+- GitHub release publish from Linux CI: `npm run build:release:linux`
+
 ## Framework Migration
 - Rebuilt the entire codebase and migrated from Vue 2.6.11 to Svelte 5.
 - Enhanced overall performance and responsiveness.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Legacy Version: [ICC Plus](https://hikawasisters.neocities.org/ICCPlus/)<br>
 
 ## Desktop Build
 - Local Linux build: `npm run build:linux`
-- Cross-platform local default: `npm run build`
+- Default release build: `npm run build`
 - GitHub release publish from Linux CI: `npm run build:release:linux`
 
 ## Framework Migration

--- a/build.js
+++ b/build.js
@@ -3,7 +3,9 @@ require('dotenv').config();
 
 module.exports = {
 	productName: 'ICC Plus 2',
+	executableName: 'icc-plus-2',
 	appId: 'com.iccplus.app',
+	artifactName: 'ICCPlus-Desktop-${version}-${os}-${arch}.${ext}',
 	files: [
 		'js/**/*',
 		'css/**/*',
@@ -42,5 +44,26 @@ module.exports = {
 	directories: {
 		buildResources: 'assets'
 	},
-	icon: 'assets/icons/icon.ico'
+	linux: {
+		category: 'Utility',
+		target: [
+			{
+				target: 'AppImage',
+				arch: [
+					'x64'
+				]
+			},
+			{
+				target: 'tar.gz',
+				arch: [
+					'x64'
+				]
+			}
+		],
+		icon: 'assets/icons/icon.png'
+	},
+	mac: {
+		icon: 'assets/icons/icon.icns'
+	},
+	icon: 'assets/icons/icon.png'
 };

--- a/build.js
+++ b/build.js
@@ -30,6 +30,7 @@ module.exports = {
 		runAfterFinish: false
 	},
 	win: {
+		icon: 'assets/icons/icon.ico',
 		verifyUpdateCodeSignature: true,
 		target: [
 			{

--- a/main.js
+++ b/main.js
@@ -58,15 +58,20 @@ function setupAutoUpdater() {
     autoUpdater.logger = log;
     autoUpdater.logger.transports.file.level = 'info';
 
-    autoUpdater.setFeedURL({
-        provider: 'github',
-        owner: 'wahaha303',
-        repo: 'ICCPlus-Desktop',
-        token: process.env.AUTO_UPDATE_TOKEN
-    });
+    if (!app.isPackaged) {
+        log.info('Skipping auto-updater for unpackaged app.');
+        return;
+    }
+
+    if (process.platform === 'linux' && !process.env.APPIMAGE) {
+        log.info('Skipping auto-updater on Linux because APPIMAGE is not set.');
+        return;
+    }
 	
 	autoUpdater.autoDownload = false;
-    autoUpdater.checkForUpdates();
+    autoUpdater.checkForUpdates().catch((error) => {
+        log.error('Failed to check for updates:', error);
+    });
 }
 
 app.whenReady().then(async () => {

--- a/main.js
+++ b/main.js
@@ -67,6 +67,13 @@ function setupAutoUpdater() {
         log.info('Skipping auto-updater on Linux because APPIMAGE is not set.');
         return;
     }
+
+	autoUpdater.setFeedURL({
+		provider: 'github',
+		owner: 'wahaha303',
+		repo: 'ICCPlus-Desktop',
+		token: process.env.AUTO_UPDATE_TOKEN
+	});
 	
 	autoUpdater.autoDownload = false;
     autoUpdater.checkForUpdates().catch((error) => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"main": "main.js",
 	"scripts": {
 		"start": "electron .",
-		"build": "electron-builder --config build.js --publish never",
+		"build": "electron-builder --config build.js --publish always",
 		"build:windows": "electron-builder --win --config build.js --publish never",
 		"build:linux": "electron-builder --linux --config build.js --publish never",
 		"build:release": "electron-builder --config build.js --publish always",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
 	"scripts": {
 		"start": "electron .",
 		"build": "electron-builder --config build.js --publish never",
+		"build:windows": "electron-builder --win --config build.js --publish never",
 		"build:linux": "electron-builder --linux --config build.js --publish never",
 		"build:release": "electron-builder --config build.js --publish always",
+		"build:release:windows": "electron-builder --win --config build.js --publish always",
 		"build:release:linux": "electron-builder --linux --config build.js --publish always"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 	"main": "main.js",
 	"scripts": {
 		"start": "electron .",
-		"build": "electron-builder --config build.js --publish always"
+		"build": "electron-builder --config build.js --publish never",
+		"build:linux": "electron-builder --linux --config build.js --publish never",
+		"build:release": "electron-builder --config build.js --publish always",
+		"build:release:linux": "electron-builder --linux --config build.js --publish always"
 	},
 	"devDependencies": {
 		"electron": "^37.3.1",


### PR DESCRIPTION
## Summary
- switch electron-builder defaults to produce Linux-friendly artifacts (AppImage and tar.gz)
- make auto-update checks safe for development builds and Linux runs without APPIMAGE
- move release automation to Ubuntu and document the Linux build flow

## Key Changes
- added Linux targets, artifact naming, and icon configuration in the electron-builder config
- updated package scripts so local builds do not publish by default and added Linux-specific build commands
- removed the hard-coded feed setup and guarded the updater for unpackaged and non-AppImage Linux runs
- changed the GitHub Actions release job from Windows to Ubuntu using npm ci
- documented the Linux build and release commands in the README

## Validation
- npm run build:linux