### PR TITLE
add mac build commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
           - os: windows-latest
             build_command: npm run build:release:windows
             label: Windows
+          - os: macos-latest
+            build_command: npm run build:mac:release
+            label: macOS
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,3 +42,4 @@ jobs:
         run: ${{ matrix.build_command }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
 		"build": "electron-builder --config build.js --publish never",
 		"build:windows": "electron-builder --win --config build.js --publish never",
 		"build:linux": "electron-builder --linux --config build.js --publish never",
+		"build:mac" : "electron-builder --mac --config build.js --publish never",
 		"build:release": "electron-builder --config build.js --publish always",
 		"build:release:windows": "electron-builder --win --config build.js --publish always",
-		"build:release:linux": "electron-builder --linux --config build.js --publish always"
+		"build:release:linux": "electron-builder --linux --config build.js --publish always",
+		"build:mac:release" : "electron-builder --mac --config build.js --publish always"
 	},
 	"devDependencies": {
 		"electron": "^37.3.1",


### PR DESCRIPTION
I've added mac os build commands. Running npm build would build the Electron app on any platform, but this way, it could be added to a runner. Mac is kinda dumb, so I've also added CSC_IDENTITY_AUTO_DISCOVERY as false, so a runner shouldn't try to sign the end result of a Mac build. I know some people who might use this program are not technical, so adding a Mac build seems like a good idea, just in case people see Linux or Windows in the release and assume it won't work.

**Do note** that I did not actually test the action, only the build commands found in the package file. I just copied some of the values from one of the projects that I make in my day job. It would probably be a good idea to give it a go before merging in Docker or something if you decide to approve this PR. 